### PR TITLE
Fix WAX oracle crashes on unrecognized signature format

### DIFF
--- a/oracle/oracle-eos.js
+++ b/oracle/oracle-eos.js
@@ -20,6 +20,29 @@ const { fork } = require('child_process');
 const Web3 = require('web3');
 const ethUtil = require('ethereumjs-util');
 
+// @eosdacio/eosio-statereceiver hardcodes fetch_block:true, which deserializes every
+// signed_block (including WA/WebAuthn tx signatures). This oracle only uses traces for
+// logteleport — never the block body or block_timestamp — so only fetch blocks when a
+// block handler is actually registered. Also matches how traces/deltas are gated.
+StateReceiver.prototype.requestBlocks = async function () {
+    try {
+        this.current_block = 0;
+
+        await this.connection.requestBlocks({
+            irreversible_only: this.irreversible_only,
+            start_block_num: parseInt(this.start_block),
+            end_block_num: parseInt(this.end_block),
+            have_positions: [],
+            fetch_block: this.block_handlers.length > 0,
+            fetch_traces: this.trace_handlers.length > 0,
+            fetch_deltas: this.delta_handlers.length > 0,
+        });
+    } catch (e) {
+        console.error(e);
+        process.exit(1);
+    }
+};
+
 const config = require(config_file);
 
 const web3 = new Web3(new Web3.providers.HttpProvider(config.eth.endpoint));

--- a/oracle/package.json
+++ b/oracle/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@eosdacio/eosio-statereceiver": "^1.0.2",
     "abi-decoder": "^2.4.0",
-    "eosjs": "^22.0.0",
+    "eosjs": "22.1.0",
     "eosio-helpers": "^0.1.4",
     "ethereumjs-util": "^7.0.4",
     "ethers": "^5.3.1",
@@ -21,5 +21,11 @@
   },
   "devDependencies": {
     "@types/text-encoding": "0.0.36"
+  },
+  "resolutions": {
+    "eosjs": "22.1.0"
+  },
+  "overrides": {
+    "eosjs": "22.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- Stop fetching SHiP `signed_block` data when the WAX oracle only registers a trace handler (`fetch_block` gated like traces/deltas). Full block deserialize was throwing on WA/WebAuthn signatures and taking the process down via `process.exit(1)`.
- Pin `eosjs` to `22.1.0` with yarn `resolutions` and npm `overrides` so `@eosdacio/eosio-statereceiver` no longer resolves nested `eosjs@20` (K1/R1 only).

## Test plan
- [x] Reproduced crash: `Error: unrecognized signature format` in `eosjs-numeric.js` during `processBlocks` → `deserialize('signed_block', ...)`.
- [x] After change: `AW-WAX-BSC-ORACLE` / `AW-WAX-ETH-ORACLE` restarted from block `444178686`, advanced through blocks with **0 restarts** and no new signature errors.
- [x] Confirmed nested `eosjs` for statereceiver resolves to **22.1.0** with `KeyType.wa`.
- [x] EVM counterparts (`oracle-eth.js`) still poll normally.