### PR TITLE
Harden WAX oracle against silent SHiP stream stalls

### DIFF
--- a/oracle/ecosystem.config.example.js
+++ b/oracle/ecosystem.config.example.js
@@ -15,9 +15,18 @@ module.exports = {
             script: "./oracle-eos.js",
             node_args: ["--max-old-space-size=8192"],
             autorestart: true,
-            kill_timeout: 3600,
+            // Last-resort process.exit(2) after SHiP recovery is exhausted
+            kill_timeout: 10000,
             env: {
-                'CONFIG': './config'
+                'CONFIG': './config',
+                // No SHiP block progress for this long → recovery ladder
+                // (force-close → rebuild → … → exit 2). 0 disables.
+                'SHIP_STALL_MS': '120000',
+                'SHIP_STALL_CHECK_MS': '30000',
+                // Application-level WS ping; terminate socket if no pong (0 = disable)
+                'SHIP_WS_PING_MS': '30000',
+                // Max recovery attempts before process.exit(2) for PM2
+                'SHIP_MAX_RECOVERIES': '4',
             },
         },
         {

--- a/oracle/lib/ship-recovery.js
+++ b/oracle/lib/ship-recovery.js
@@ -1,0 +1,316 @@
+'use strict';
+
+/**
+ * SHiP stream recovery policy for the WAX oracle.
+ *
+ * eosio-statereceiver only reconnects on websocket *close*. Half-open sockets
+ * (no close, no further blocks) leave the process online with a frozen cursor.
+ *
+ * Recovery ladder (resets to step 0 after block progress resumes):
+ *   1) force-close socket → library reconnect (preserves in-flight work)
+ *   2) rebuild StateReceiver from durable cursor
+ *   3) after maxRecoveries failed attempts → give up (caller may process.exit)
+ *
+ * This module is intentionally free of SHiP/eosjs deps so it can be unit-tested.
+ */
+
+const DEFAULTS = {
+    stallMs: 120_000,
+    checkMs: 30_000,
+    wsPingMs: 30_000,
+    maxRecoveries: 4,
+};
+
+function parseEnvInt(name, fallback, env = process.env) {
+    const raw = env[name];
+    if (raw === undefined || raw === '') return fallback;
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) ? n : fallback;
+}
+
+function configFromEnv(env = process.env) {
+    return {
+        stallMs: parseEnvInt('SHIP_STALL_MS', DEFAULTS.stallMs, env),
+        checkMs: parseEnvInt('SHIP_STALL_CHECK_MS', DEFAULTS.checkMs, env),
+        wsPingMs: parseEnvInt('SHIP_WS_PING_MS', DEFAULTS.wsPingMs, env),
+        maxRecoveries: parseEnvInt('SHIP_MAX_RECOVERIES', DEFAULTS.maxRecoveries, env),
+    };
+}
+
+/**
+ * @typedef {object} ShipRecoveryHooks
+ * @property {() => void|Promise<void>} forceClose  Terminate half-open socket
+ * @property {() => void|Promise<void>} rebuild     Tear down + new StateReceiver
+ * @property {(info: object) => void|Promise<void>} giveUp  Final failure
+ * @property {(msg: string, extra?: object) => void} [log]
+ * @property {(msg: string, extra?: object) => void} [error]
+ */
+
+class ShipRecoveryController {
+    /**
+     * @param {Partial<typeof DEFAULTS> & ShipRecoveryHooks} opts
+     */
+    constructor(opts) {
+        const {
+            forceClose,
+            rebuild,
+            giveUp,
+            log = console.log.bind(console),
+            error = console.error.bind(console),
+            stallMs = DEFAULTS.stallMs,
+            checkMs = DEFAULTS.checkMs,
+            wsPingMs = DEFAULTS.wsPingMs,
+            maxRecoveries = DEFAULTS.maxRecoveries,
+            now = () => Date.now(),
+        } = opts;
+
+        if (typeof forceClose !== 'function') throw new Error('forceClose required');
+        if (typeof rebuild !== 'function') throw new Error('rebuild required');
+        if (typeof giveUp !== 'function') throw new Error('giveUp required');
+
+        this.forceClose = forceClose;
+        this.rebuild = rebuild;
+        this.giveUp = giveUp;
+        this.log = log;
+        this.error = error;
+        this.now = now;
+
+        this.stallMs = stallMs;
+        this.checkMs = checkMs;
+        this.wsPingMs = wsPingMs;
+        this.maxRecoveries = maxRecoveries;
+
+        this.lastProgressAt = this.now();
+        this.lastProgressBlock = 0;
+        this.recoveryAttempts = 0;
+        this.recovering = false;
+        this._timer = null;
+        this._started = false;
+    }
+
+    /** Record that a block was applied (or stream became healthy again). */
+    noteProgress(blockNum) {
+        this.lastProgressAt = this.now();
+        if (blockNum) {
+            if (this.recoveryAttempts > 0) {
+                this.log(
+                    `SHiP progress restored at block ${blockNum} after ${this.recoveryAttempts} recovery attempt(s)`
+                );
+                this.recoveryAttempts = 0;
+            }
+            this.lastProgressBlock = blockNum;
+        }
+    }
+
+    /** Soft touch of the idle timer without counting as recovery success. */
+    armGrace() {
+        this.lastProgressAt = this.now();
+    }
+
+    idleMs(now = this.now()) {
+        return now - this.lastProgressAt;
+    }
+
+    isStalled(now = this.now()) {
+        if (!this.stallMs || this.stallMs <= 0) return false;
+        return this.idleMs(now) >= this.stallMs;
+    }
+
+    /**
+     * Decide next recovery action for a stall.
+     * @returns {'forceClose'|'rebuild'|'giveUp'|null}
+     */
+    nextAction() {
+        if (this.recovering) return null;
+        if (!this.isStalled()) return null;
+
+        // Attempts so far already failed to restore progress.
+        if (this.recoveryAttempts >= this.maxRecoveries) {
+            return 'giveUp';
+        }
+
+        // Odd steps (1st, 3rd, …): force-close for library reconnect.
+        // Even steps (2nd, 4th, …): full receiver rebuild from cursor.
+        const next = this.recoveryAttempts + 1;
+        return next % 2 === 1 ? 'forceClose' : 'rebuild';
+    }
+
+    /**
+     * Run one recovery step if stalled. Safe to call from an interval.
+     * @returns {Promise<'forceClose'|'rebuild'|'giveUp'|'skipped'|'disabled'>}
+     */
+    async tick() {
+        if (!this.stallMs || this.stallMs <= 0) {
+            return 'disabled';
+        }
+        if (this.recovering) {
+            return 'skipped';
+        }
+        if (!this.isStalled()) {
+            return 'skipped';
+        }
+
+        const action = this.nextAction();
+        if (!action) {
+            return 'skipped';
+        }
+
+        const idle = this.idleMs();
+        const lastBlock = this.lastProgressBlock || 'none';
+
+        if (action === 'giveUp') {
+            this.error(
+                `SHiP stall unrecovered after ${this.recoveryAttempts} attempt(s): ` +
+                    `no block progress for ${Math.round(idle / 1000)}s ` +
+                    `(last_block=${lastBlock}). Giving up.`
+            );
+            this.recovering = true;
+            try {
+                await this.giveUp({
+                    idleMs: idle,
+                    lastBlock: this.lastProgressBlock,
+                    recoveryAttempts: this.recoveryAttempts,
+                });
+            } finally {
+                this.recovering = false;
+            }
+            return 'giveUp';
+        }
+
+        this.recovering = true;
+        this.recoveryAttempts += 1;
+        try {
+            if (action === 'forceClose') {
+                this.error(
+                    `SHiP stall detected: no block progress for ${Math.round(idle / 1000)}s ` +
+                        `(last_block=${lastBlock}). Recovery #${this.recoveryAttempts}/${this.maxRecoveries}: force-close socket.`
+                );
+                await this.forceClose();
+            } else {
+                this.error(
+                    `SHiP stall detected: no block progress for ${Math.round(idle / 1000)}s ` +
+                        `(last_block=${lastBlock}). Recovery #${this.recoveryAttempts}/${this.maxRecoveries}: rebuild receiver from cursor.`
+                );
+                await this.rebuild();
+            }
+            // Grace period so reconnect/catch-up is not treated as another stall.
+            this.armGrace();
+        } catch (e) {
+            this.error(
+                `SHiP recovery action ${action} failed: ${e && e.message ? e.message : e}`
+            );
+            this.armGrace();
+        } finally {
+            this.recovering = false;
+        }
+        return action;
+    }
+
+    start() {
+        if (this._started) return;
+        if (!this.stallMs || this.stallMs <= 0) {
+            this.log('SHiP stall recovery disabled (SHIP_STALL_MS<=0)');
+            return;
+        }
+        this._started = true;
+        this.armGrace();
+        this.log(
+            `SHiP stall recovery armed (stall=${this.stallMs}ms check=${this.checkMs}ms ` +
+                `ping=${this.wsPingMs}ms maxRecoveries=${this.maxRecoveries})`
+        );
+        const interval = Math.max(1000, this.checkMs || 30_000);
+        this._timer = setInterval(() => {
+            this.tick().catch((e) => {
+                this.error(`SHiP recovery tick error: ${e && e.message ? e.message : e}`);
+            });
+        }, interval);
+        // Keep the timer referenced so recovery runs for the process lifetime.
+        if (typeof this._timer.unref === 'function') {
+            // Do not unref — we want the watchdog to stay active.
+        }
+    }
+
+    stop() {
+        if (this._timer) {
+            clearInterval(this._timer);
+            this._timer = null;
+        }
+        this._started = false;
+    }
+}
+
+/**
+ * Install application-level WS ping/pong on a live `ws` instance.
+ * On missing pong, terminate the socket so the library's close/reconnect path runs.
+ *
+ * @param {import('ws')} ws
+ * @param {{ pingMs: number, error?: Function }} opts
+ * @returns {() => void} dispose
+ */
+function installWsHeartbeat(ws, opts) {
+    const pingMs = opts && opts.pingMs;
+    const error = (opts && opts.error) || console.error.bind(console);
+    if (!pingMs || pingMs <= 0 || !ws) {
+        return () => {};
+    }
+    if (ws.__oracleHeartbeatInstalled) {
+        return () => {};
+    }
+    ws.__oracleHeartbeatInstalled = true;
+
+    let alive = true;
+    const onPong = () => {
+        alive = true;
+    };
+    ws.on('pong', onPong);
+
+    const iv = setInterval(() => {
+        if (ws.readyState !== ws.OPEN) {
+            clearInterval(iv);
+            return;
+        }
+        if (!alive) {
+            error('SHiP websocket ping timeout — terminating socket to force reconnect');
+            try {
+                ws.terminate();
+            } catch (_) {
+                /* ignore */
+            }
+            clearInterval(iv);
+            return;
+        }
+        alive = false;
+        try {
+            ws.ping();
+        } catch (_) {
+            /* ignore */
+        }
+    }, pingMs);
+
+    const onClose = () => {
+        clearInterval(iv);
+        try {
+            ws.removeListener('pong', onPong);
+        } catch (_) {
+            /* ignore */
+        }
+    };
+    ws.once('close', onClose);
+
+    return () => {
+        clearInterval(iv);
+        try {
+            ws.removeListener('pong', onPong);
+            ws.removeListener('close', onClose);
+        } catch (_) {
+            /* ignore */
+        }
+    };
+}
+
+module.exports = {
+    DEFAULTS,
+    configFromEnv,
+    ShipRecoveryController,
+    installWsHeartbeat,
+};

--- a/oracle/oracle-eos.js
+++ b/oracle/oracle-eos.js
@@ -21,6 +21,12 @@ const { fork } = require('child_process');
 const Web3 = require('web3');
 const ethUtil = require('ethereumjs-util');
 
+const {
+    configFromEnv: shipConfigFromEnv,
+    ShipRecoveryController,
+    installWsHeartbeat,
+} = require('./lib/ship-recovery');
+
 // @eosdacio/eosio-statereceiver hardcodes fetch_block:true, which deserializes every
 // signed_block (including WA/WebAuthn tx signatures). This oracle only uses traces for
 // logteleport — never the block body or block_timestamp — so only fetch blocks when a
@@ -78,6 +84,18 @@ const save_wax_block = (block_num) => {
     } catch (e) {
         console.error(`Failed to save WAX cursor ${block_num}: ${e.message}`);
     }
+};
+
+const resolve_start_block = (explicit) => {
+    if (typeof explicit === 'number' && Number.isFinite(explicit)) {
+        return Math.max(1, explicit);
+    }
+    const saved = load_wax_block();
+    if (saved != null) {
+        // small rewind for reorg/overlap safety (mirrors oracle-eth -50)
+        return Math.max(1, saved - 50);
+    }
+    return null;
 };
 
 // const ethAbi = require(`./eth_abi`);
@@ -207,29 +225,157 @@ class TraceHandler {
     }
 }
 
+/**
+ * Owns the StateReceiver lifecycle so SHiP stalls can recover without killing
+ * the process (and without dropping the TraceHandler signature queue).
+ */
+class ShipSession {
+    constructor({ config, trace_handler, shipCfg }) {
+        this.config = config;
+        this.trace_handler = trace_handler;
+        this.shipCfg = shipCfg;
+        this.sr = null;
+        this.recovery = null;
+    }
+
+    _wsState() {
+        try {
+            const conn = this.sr && this.sr.connection;
+            if (conn && conn.ws) return String(conn.ws.readyState);
+            if (conn) return `connected=${!!conn.connected} connecting=${!!conn.connecting}`;
+        } catch (_) {
+            /* ignore */
+        }
+        return 'n/a';
+    }
+
+    _disposeReceiver() {
+        const sr = this.sr;
+        this.sr = null;
+        if (!sr || !sr.connection) return;
+        const conn = sr.connection;
+        try {
+            // Prevent the library from reconnecting the socket we are replacing.
+            // disconnect() uses the default close code 1000 (no auto-reconnect).
+            conn.maxConnectionRetries = -1;
+            if (conn.ws) {
+                conn.disconnect();
+            }
+        } catch (e) {
+            console.error(`SHiP dispose error: ${e.message}`);
+            try {
+                if (conn.ws) conn.ws.terminate();
+            } catch (_) {
+                /* ignore */
+            }
+        }
+    }
+
+    _createReceiver(start_block) {
+        const sr = new StateReceiver({
+            startBlock: start_block,
+            endBlock: 0xffffffff,
+            mode: 0,
+            config: this.config,
+            irreversibleOnly: true
+        });
+
+        const _receivedBlock = sr.receivedBlock.bind(sr);
+        sr.receivedBlock = async (response, block, traces, deltas) => {
+            if (response && response.this_block && response.this_block.block_num) {
+                const block_num = response.this_block.block_num;
+                save_wax_block(block_num);
+                if (this.recovery) {
+                    this.recovery.noteProgress(block_num);
+                }
+            }
+            return _receivedBlock(response, block, traces, deltas);
+        };
+
+        // Heartbeat re-armed on each (re)connect when ABI arrives.
+        // Do not armGrace here: a socket that handshakes but never delivers blocks
+        // must still trip the stall timer (armGrace is applied after recovery actions).
+        sr.registerConnectedHandler((connection) => {
+            if (this.recovery) {
+                installWsHeartbeat(connection.ws, {
+                    pingMs: this.shipCfg.wsPingMs,
+                    error: console.error.bind(console),
+                });
+            }
+        });
+
+        sr.registerTraceHandler(this.trace_handler);
+        return sr;
+    }
+
+    async start(start_block) {
+        this._disposeReceiver();
+        this.sr = this._createReceiver(start_block);
+        this.sr.start();
+
+        if (!this.recovery) {
+            this.recovery = new ShipRecoveryController({
+                ...this.shipCfg,
+                forceClose: async () => this.forceCloseSocket(),
+                rebuild: async () => this.rebuildFromCursor(),
+                giveUp: async (info) => {
+                    console.error(
+                        `SHiP recovery exhausted (attempts=${info.recoveryAttempts}, ` +
+                            `last_block=${info.lastBlock || 'none'}, ws_readyState=${this._wsState()}). ` +
+                            `Exiting so PM2 can restart from saved cursor.`
+                    );
+                    process.exit(2);
+                },
+            });
+            this.recovery.start();
+        }
+    }
+
+    forceCloseSocket() {
+        const conn = this.sr && this.sr.connection;
+        if (!conn || !conn.ws) {
+            console.error('SHiP force-close: no active websocket; rebuilding instead');
+            return this.rebuildFromCursor();
+        }
+        console.error(
+            `SHiP force-close websocket (readyState=${conn.ws.readyState}) to trigger library reconnect`
+        );
+        try {
+            // Abnormal close → Connection.onClose reconnects (code !== 1000).
+            // currentArgs (start_block_num) is preserved across reconnect in the library.
+            conn.ws.terminate();
+        } catch (e) {
+            console.error(`SHiP force-close failed: ${e.message}`);
+            return this.rebuildFromCursor();
+        }
+    }
+
+    async rebuildFromCursor() {
+        let start_block = resolve_start_block();
+        if (start_block == null) {
+            try {
+                const info = await rpc.get_info();
+                start_block = info.head_block_num;
+            } catch (e) {
+                console.error(`SHiP rebuild: cannot resolve start block: ${e.message}`);
+                throw e;
+            }
+        }
+        console.error(
+            `SHiP rebuild StateReceiver from block ${start_block} ` +
+                `(saved=${load_wax_block()}, last_progress=${this.recovery ? this.recovery.lastProgressBlock : 'n/a'})`
+        );
+        this._disposeReceiver();
+        this.sr = this._createReceiver(start_block);
+        this.sr.start();
+    }
+}
 
 const start = async (config, start_block) => {
     const trace_handler = new TraceHandler({ config });
-
-    const sr = new StateReceiver({
-        startBlock: start_block,
-        endBlock: 0xffffffff,
-        mode: 0,
-        config,
-        irreversibleOnly: true
-    });
-
-    // Persist cursor on every block (before start() binds receivedBlock)
-    const _receivedBlock = sr.receivedBlock.bind(sr);
-    sr.receivedBlock = async function (response, block, traces, deltas) {
-        if (response && response.this_block && response.this_block.block_num) {
-            save_wax_block(response.this_block.block_num);
-        }
-        return _receivedBlock(response, block, traces, deltas);
-    };
-
-    sr.registerTraceHandler(trace_handler);
-    sr.start();
+    const shipCfg = shipConfigFromEnv();
+    const session = new ShipSession({ config, trace_handler, shipCfg });
+    await session.start(start_block);
 }
 
 const run = async (config) => {
@@ -247,7 +393,6 @@ const run = async (config) => {
     } else {
         const saved = load_wax_block();
         if (saved != null) {
-            // small rewind for reorg/overlap safety (mirrors oracle-eth -50)
             start_block = Math.max(1, saved - 50);
             console.log(`Starting from saved WAX block ${saved} (rewind to ${start_block})`);
         } else {

--- a/oracle/package.json
+++ b/oracle/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test/ship-recovery.test.js",
     "monitor": "node monitor-teleports.js",
     "monitor:once": "node monitor-teleports.js --once"
   },

--- a/oracle/test/ship-recovery.test.js
+++ b/oracle/test/ship-recovery.test.js
@@ -1,0 +1,183 @@
+'use strict';
+
+/**
+ * Lightweight tests for SHiP recovery policy (no SHiP/network).
+ * Run: node test/ship-recovery.test.js
+ */
+
+const assert = require('assert');
+const {
+    ShipRecoveryController,
+    configFromEnv,
+} = require('../lib/ship-recovery');
+
+function test(name, fn) {
+    try {
+        fn();
+        console.log(`  ok  ${name}`);
+    } catch (e) {
+        console.error(`  FAIL ${name}`);
+        console.error(e);
+        process.exitCode = 1;
+    }
+}
+
+async function testAsync(name, fn) {
+    try {
+        await fn();
+        console.log(`  ok  ${name}`);
+    } catch (e) {
+        console.error(`  FAIL ${name}`);
+        console.error(e);
+        process.exitCode = 1;
+    }
+}
+
+console.log('ship-recovery');
+
+test('configFromEnv defaults', () => {
+    const c = configFromEnv({});
+    assert.strictEqual(c.stallMs, 120000);
+    assert.strictEqual(c.maxRecoveries, 4);
+});
+
+test('configFromEnv overrides', () => {
+    const c = configFromEnv({
+        SHIP_STALL_MS: '5000',
+        SHIP_MAX_RECOVERIES: '2',
+        SHIP_WS_PING_MS: '0',
+    });
+    assert.strictEqual(c.stallMs, 5000);
+    assert.strictEqual(c.maxRecoveries, 2);
+    assert.strictEqual(c.wsPingMs, 0);
+});
+
+(async () => {
+    await testAsync('ladder: forceClose → rebuild → forceClose → rebuild → giveUp', async () => {
+        const actions = [];
+        let now = 1_000_000;
+        const ctl = new ShipRecoveryController({
+            stallMs: 1000,
+            checkMs: 100,
+            maxRecoveries: 4,
+            now: () => now,
+            log: () => {},
+            error: () => {},
+            forceClose: async () => {
+                actions.push('forceClose');
+            },
+            rebuild: async () => {
+                actions.push('rebuild');
+            },
+            giveUp: async () => {
+                actions.push('giveUp');
+            },
+        });
+
+        // Not stalled yet
+        assert.strictEqual(await ctl.tick(), 'skipped');
+
+        now += 2000; // stall
+        assert.strictEqual(await ctl.tick(), 'forceClose');
+        assert.strictEqual(ctl.recoveryAttempts, 1);
+
+        // Grace was armed; not stalled until another stall window
+        assert.strictEqual(await ctl.tick(), 'skipped');
+        now += 2000;
+        assert.strictEqual(await ctl.tick(), 'rebuild');
+        assert.strictEqual(ctl.recoveryAttempts, 2);
+
+        now += 2000;
+        assert.strictEqual(await ctl.tick(), 'forceClose');
+        now += 2000;
+        assert.strictEqual(await ctl.tick(), 'rebuild');
+        assert.strictEqual(ctl.recoveryAttempts, 4);
+
+        now += 2000;
+        assert.strictEqual(await ctl.tick(), 'giveUp');
+        assert.deepStrictEqual(actions, [
+            'forceClose',
+            'rebuild',
+            'forceClose',
+            'rebuild',
+            'giveUp',
+        ]);
+    });
+
+    await testAsync('progress after recovery resets attempt counter', async () => {
+        let now = 0;
+        const actions = [];
+        const ctl = new ShipRecoveryController({
+            stallMs: 100,
+            maxRecoveries: 4,
+            now: () => now,
+            log: () => {},
+            error: () => {},
+            forceClose: async () => actions.push('forceClose'),
+            rebuild: async () => actions.push('rebuild'),
+            giveUp: async () => actions.push('giveUp'),
+        });
+
+        now = 1000;
+        assert.strictEqual(await ctl.tick(), 'forceClose');
+        assert.strictEqual(ctl.recoveryAttempts, 1);
+
+        // Stream recovers
+        now = 1100;
+        ctl.noteProgress(42);
+        assert.strictEqual(ctl.recoveryAttempts, 0);
+
+        // Stall again → starts over at forceClose
+        now = 2000;
+        assert.strictEqual(await ctl.tick(), 'forceClose');
+        assert.deepStrictEqual(actions, ['forceClose', 'forceClose']);
+    });
+
+    await testAsync('disabled when stallMs<=0', async () => {
+        const ctl = new ShipRecoveryController({
+            stallMs: 0,
+            forceClose: async () => {
+                throw new Error('should not run');
+            },
+            rebuild: async () => {
+                throw new Error('should not run');
+            },
+            giveUp: async () => {
+                throw new Error('should not run');
+            },
+            log: () => {},
+            error: () => {},
+        });
+        assert.strictEqual(await ctl.tick(), 'disabled');
+    });
+
+    await testAsync('concurrent tick is skipped while recovering', async () => {
+        let now = 0;
+        let release;
+        const gate = new Promise((r) => {
+            release = r;
+        });
+        const ctl = new ShipRecoveryController({
+            stallMs: 10,
+            now: () => now,
+            log: () => {},
+            error: () => {},
+            forceClose: async () => {
+                await gate;
+            },
+            rebuild: async () => {},
+            giveUp: async () => {},
+        });
+        now = 100;
+        const p = ctl.tick();
+        assert.strictEqual(await ctl.tick(), 'skipped');
+        release();
+        assert.strictEqual(await p, 'forceClose');
+    });
+
+    if (process.exitCode) {
+        console.error('some tests failed');
+        process.exit(process.exitCode);
+    }
+    console.log('all tests passed');
+})();


### PR DESCRIPTION
## Summary

- Fix multi-hour freezes where WAX SHiP websockets go half-open: no `close` event, so `@eosdacio/eosio-statereceiver` never reconnects, PM2 still shows the process online, and the durable cursor stops advancing (observed ~20h on 2026-07-24 and ~8h on 2026-07-28).
- Recover **in-process** so the signature queue and `txdispatch` child are not dropped:
  1. **WS ping/pong** — terminate the socket on missing pong so the library’s close/reconnect path runs
  2. **Force-close** on stall — library reconnect (preserves `currentArgs` resume point)
  3. **Rebuild** `StateReceiver` from the durable WAX cursor on the next stall
  4. **Last resort** — after `SHIP_MAX_RECOVERIES` (default 4) failed attempts, `process.exit(2)` for PM2
- Extract policy to `oracle/lib/ship-recovery.js` with unit tests (`npm test` in `oracle/`).

## Config (optional env)

| Env | Default | Meaning |
|---|---|---|
| `SHIP_STALL_MS` | `120000` | No block progress → recovery step (`0` disables) |
| `SHIP_STALL_CHECK_MS` | `30000` | Check interval |
| `SHIP_WS_PING_MS` | `30000` | WS ping interval (`0` disables) |
| `SHIP_MAX_RECOVERIES` | `4` | Attempts before exit 2 |

Documented in `oracle/ecosystem.config.example.js`.

## Test plan

- [x] `cd oracle && npm test` (recovery ladder unit tests)
- [x] `node --check oracle-eos.js`
- [ ] Deploy to a WAX oracle process: confirm log line `SHiP stall recovery armed ...` on start
- [ ] Confirm normal operation: cursor advances, signatures still push
- [ ] Optional: temporarily set `SHIP_STALL_MS=15000` and block SHiP briefly; expect force-close / rebuild logs, not immediate exit
- [ ] After recovery, `MISSING MY APPROVAL` / lag should clear without a manual PM2 restart